### PR TITLE
🚚 Move DD sampling to MQT DDSIM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dynamic = ["version"]
 
 dependencies = [
     "mqt.core>=3.8.0",
-    "mqt.ddsim>=2.6.0; python_version >= '3.11'",
+    "mqt.ddsim>=2.6.0",
     "qiskit>=2.0.3",
     "qiskit_aer>=0.16.4; python_version < '3.14'",
     "numpy>=1.24",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dynamic = ["version"]
 
 dependencies = [
     "mqt.core>=3.8.0",
+    "mqt.ddsim>=2.6.0; python_version >= '3.11'",
     "qiskit>=2.0.3",
     "qiskit_aer>=0.16.4; python_version < '3.14'",
     "numpy>=1.24",

--- a/src/mqt/problemsolver/csp.py
+++ b/src/mqt/problemsolver/csp.py
@@ -8,12 +8,17 @@
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING, TypedDict
 
 import numpy as np
 from mqt.core import load
-from mqt.core.dd import sample
 from qiskit import QuantumCircuit, QuantumRegister
+
+if sys.version_info >= (3, 11):
+    from mqt.ddsim import sample
+else:
+    from mqt.core.dd import sample
 
 if TYPE_CHECKING:
     from qiskit.circuit import Instruction

--- a/src/mqt/problemsolver/csp.py
+++ b/src/mqt/problemsolver/csp.py
@@ -8,17 +8,12 @@
 
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING, TypedDict
 
 import numpy as np
 from mqt.core import load
+from mqt.ddsim import sample
 from qiskit import QuantumCircuit, QuantumRegister
-
-if sys.version_info >= (3, 11):
-    from mqt.ddsim import sample
-else:
-    from mqt.core.dd import sample
 
 if TYPE_CHECKING:
     from qiskit.circuit import Instruction

--- a/src/mqt/problemsolver/tsp.py
+++ b/src/mqt/problemsolver/tsp.py
@@ -9,16 +9,21 @@
 # Code is adapted from https://arxiv.org/abs/1805.10928 and https://qiskit.org/textbook/ch-paper-implementations/tsp.html
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING, cast
 
 import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
 from mqt.core import load
-from mqt.core.dd import sample
 from python_tsp.exact import solve_tsp_dynamic_programming
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.synthesis.qft import synth_qft_full
+
+if sys.version_info >= (3, 11):
+    from mqt.ddsim import sample
+else:
+    from mqt.core.dd import sample
 
 if TYPE_CHECKING:
     from qiskit.circuit import Gate

--- a/src/mqt/problemsolver/tsp.py
+++ b/src/mqt/problemsolver/tsp.py
@@ -9,21 +9,16 @@
 # Code is adapted from https://arxiv.org/abs/1805.10928 and https://qiskit.org/textbook/ch-paper-implementations/tsp.html
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING, cast
 
 import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
 from mqt.core import load
+from mqt.ddsim import sample
 from python_tsp.exact import solve_tsp_dynamic_programming
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.synthesis.qft import synth_qft_full
-
-if sys.version_info >= (3, 11):
-    from mqt.ddsim import sample
-else:
-    from mqt.core.dd import sample
 
 if TYPE_CHECKING:
     from qiskit.circuit import Gate


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Move the DD sampling used by the CSP and TSP solvers from `mqt.core.dd` to
`mqt.ddsim`, where the high-level simulator API is moving as part of
munich-quantum-toolkit/core#2103.

ProblemSolver now requires Python 3.11 after #528, so this branch imports
`sample` from DDSIM unconditionally and adds `mqt.ddsim>=2.6.0`. No
ProblemSolver API or solver behavior is intended to change.

## Dependencies and merge order

This draft depends on munich-quantum-toolkit/core#2273,
munich-quantum-toolkit/ddsim#978, and the publication of MQT DDSIM 2.6.0. Once
that release is available, regenerate and commit `uv.lock`, run the full
lint/test checks, and mark this pull request ready for review.

## Validation

- source formatting, Ruff, and Markdown checks pass
- the `uv-lock` and `ty` checks cannot resolve the unreleased DDSIM 2.6.0
  dependency yet

## AI assistance

Codex materially assisted with implementation, validation, review, and this pull
request description. A human must review and understand the changes before
marking this pull request ready.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] Existing CSP and TSP tests cover the migrated sampling paths.
- [x] No documentation update is required because the ProblemSolver API and behavior are unchanged.
- [x] The changes follow the project's style guidelines and introduce no new warnings. Source checks pass; dependency-resolution checks await DDSIM 2.6.0.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/problemsolver/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
